### PR TITLE
fix(request_logs): Remove unnecessary endpoints and log requests dire…

### DIFF
--- a/monarca/seeds/request-logs.json
+++ b/monarca/seeds/request-logs.json
@@ -1,18 +1,18 @@
- [
-    {
-      "id": "acb7cab5-477a-405b-8d80-79e6df65e138",
-      "id_request": "581c998a-9f67-4431-b6ab-635ec9794ba7",
-      "id_user": "5932b459-a3ea-46a1-8482-d56bfda8c866",
-      "old_status": "pending",
-      "new_status": "submitted",
-      "change_date": "2025-05-12T22:00:00Z"
-    },
-    {
-      "id": "5c9485d4-a47a-4f14-8de0-274db0d09bec",
-      "id_request": "158c357b-762a-4781-a86f-66485076e5d7",
-      "id_user": "5932b459-a3ea-46a1-8482-d56bfda8c866",
-      "old_status": "submitted",
-      "new_status": "approved",
-      "change_date": "2025-05-12T22:05:00Z"
-    }
-  ]
+[
+  {
+    "id": "acb7cab5-477a-405b-8d80-79e6df65e138",
+    "id_request": "581c998a-9f67-4431-b6ab-635ec9794ba7",
+    "id_user": "5932b459-a3ea-46a1-8482-d56bfda8c866",
+    "report": "Editó",
+    "new_status": "submitted",
+    "change_date": "2025-05-12T22:00:00Z"
+  },
+  {
+    "id": "5c9485d4-a47a-4f14-8de0-274db0d09bec",
+    "id_request": "158c357b-762a-4781-a86f-66485076e5d7",
+    "id_user": "5932b459-a3ea-46a1-8482-d56bfda8c866",
+    "report": "Aprobó",
+    "new_status": "approved",
+    "change_date": "2025-05-12T22:05:00Z"
+  }
+]

--- a/monarca/src/destinations/destinations.checks.ts
+++ b/monarca/src/destinations/destinations.checks.ts
@@ -17,4 +17,9 @@ export class DestinationsChecks {
 
     return !!dest;
   }
+
+  async getCityNameById(id: string): Promise<string> {
+    const dest = await this.destRepo.findOneBy({ id });
+    return dest?.city || 'Ciudad desconocida';
+  }
 }

--- a/monarca/src/request-logs/dto/create-request-log.dto.ts
+++ b/monarca/src/request-logs/dto/create-request-log.dto.ts
@@ -17,11 +17,13 @@ export class CreateRequestLogDto {
   id_user: string;
 
   @ApiProperty({
-    description: 'Status before the change',
-    example: 'pending',
+    description: 'Descriptive report of the change (e.g., "Editó")',
+    example: 'Editó',
+    required: false,
   })
+  @IsOptional()
   @IsString()
-  old_status: string;
+  report?: string;
 
   @ApiProperty({
     description: 'Status after the change',

--- a/monarca/src/request-logs/entities/request-log.entity.ts
+++ b/monarca/src/request-logs/entities/request-log.entity.ts
@@ -18,8 +18,12 @@ export class RequestLog {
   @Column({ name: 'id_user' })
   id_user: string;
 
-  @Column({ name: 'old_status' })
-  old_status: string;
+  @Column({
+    name: 'report',
+    type: 'varchar',
+    nullable: true,
+  })
+  report: string | null;
 
   @Column({ name: 'new_status' })
   new_status: string;

--- a/monarca/src/request-logs/request-logs.controller.ts
+++ b/monarca/src/request-logs/request-logs.controller.ts
@@ -18,17 +18,6 @@ import { UpdateRequestLogDto } from './dto/update-request-log.dto';
 export class RequestLogsController {
   constructor(private readonly logsService: RequestLogsService) {}
 
-  @Post()
-  async create(
-    @Body() data: CreateRequestLogDto,
-    @Res({ passthrough: true }) res: Response,
-  ) {
-    console.log('CreateRequestLogDto:', data);
-    const result = await this.logsService.create(data);
-    res.status(201);
-    return result;
-  }
-
   @Get()
   async findAll() {
     return this.logsService.findAll();
@@ -37,18 +26,5 @@ export class RequestLogsController {
   @Get(':id')
   async findOne(@Param('id', new ParseUUIDPipe()) id: string) {
     return this.logsService.findOne(id);
-  }
-
-  @Patch(':id')
-  async update(
-    @Param('id', new ParseUUIDPipe()) id: string,
-    @Body() data: UpdateRequestLogDto,
-  ) {
-    return this.logsService.update(id, data);
-  }
-
-  @Delete(':id')
-  async remove(@Param('id', new ParseUUIDPipe()) id: string) {
-    return this.logsService.remove(id);
   }
 }

--- a/monarca/src/request-logs/request-logs.module.ts
+++ b/monarca/src/request-logs/request-logs.module.ts
@@ -8,6 +8,6 @@ import { RequestLogsController } from './request-logs.controller';
   imports: [TypeOrmModule.forFeature([RequestLog])],
   controllers: [RequestLogsController],
   providers: [RequestLogsService],
-  exports: [RequestLogsService],
+  exports: [TypeOrmModule, RequestLogsService],
 })
 export class RequestLogsModule {}

--- a/monarca/src/request-logs/request-logs.service.ts
+++ b/monarca/src/request-logs/request-logs.service.ts
@@ -12,11 +12,6 @@ export class RequestLogsService {
     private readonly repo: Repository<RequestLog>,
   ) {}
 
-  async create(data: CreateRequestLogDto): Promise<RequestLog> {
-    const ent = this.repo.create(data);
-    return this.repo.save(ent);
-  }
-
   async findAll(): Promise<RequestLog[]> {
     return this.repo.find();
   }
@@ -25,15 +20,5 @@ export class RequestLogsService {
     const ent = await this.repo.findOneBy({ id });
     if (!ent) throw new NotFoundException(`Log ${id} not found`);
     return ent;
-  }
-
-  async update(id: string, data: UpdateRequestLogDto): Promise<RequestLog> {
-    await this.repo.update(id, data);
-    return this.findOne(id);
-  }
-
-  async remove(id: string): Promise<{ status: boolean; message: string }> {
-    await this.repo.delete(id);
-    return { status: true, message: `Log ${id} removed` };
   }
 }

--- a/monarca/src/requests/requests.module.ts
+++ b/monarca/src/requests/requests.module.ts
@@ -12,6 +12,7 @@ import { RequestsStatusController } from './requests.status.controller';
 import { RequestsStatusService } from './requests.status.service';
 import { TravelAgenciesChecks } from 'src/travel-agencies/travel-agencies.checks';
 import { TravelAgenciesModule } from 'src/travel-agencies/travel-agencies.module';
+import { RequestLogsModule } from 'src/request-logs/request-logs.module';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { TravelAgenciesModule } from 'src/travel-agencies/travel-agencies.module
     UsersModule,
     DestinationsModule,
     TravelAgenciesModule,
+    RequestLogsModule,
   ],
   controllers: [RequestsController, RequestsStatusController],
   providers: [RequestsService, RequestsChecks, RequestsStatusService],


### PR DESCRIPTION
- Removed POST, PATCH, and DELETE endpoints in request_logs, since they aren't used.
- Added logs directly in create and update functions in requests.
- Changed entity of request_logs to remove old status, and just put a report for each log (Still need to change the report depending on the situation, but this is just a first version that works fine)